### PR TITLE
optimizing cached dependencies and stored in volume on docker host

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,12 +7,11 @@ WORKDIR /usr/src/app
 ENV GRADLE_USER_HOME /opt
 COPY docker/gradle-config/ $GRADLE_USER_HOME/
 
-#
-#RUN mkdir /opt/wrapper
-#VOLUME /opt/wrapper
-#
-#RUN mkdir /opt/caches
-#VOLUME /opt/caches
+RUN mkdir /opt/wrapper
+VOLUME /opt/wrapper
+
+RUN mkdir /opt/caches
+VOLUME /opt/caches
 
 COPY gradle/ ./gradle
 COPY gradlew ./


### PR DESCRIPTION
added `/opt/wrapper` and `/opt/caches` as volumes in Dockerfile

aforementioned folders in standard gradle config located in `~/.gradle/`  (`GRADLE_USER_HOME`)
this fix allows us to improve performance of gradle builds in Docker reducing redundant downloads.

Please give advice if this approach is acceptable for shared docker-host?
how to reduce making garbage volumes?